### PR TITLE
Add in the ability to control via parameters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-find_package(ament_cmake_ros REQUIRED)
+find_package(ament_cmake REQUIRED)
 
 find_package(geometry_msgs REQUIRED)
 find_package(rclcpp REQUIRED)

--- a/include/teleop_twist_joy/teleop_twist_joy.h
+++ b/include/teleop_twist_joy/teleop_twist_joy.h
@@ -33,10 +33,12 @@ namespace teleop_twist_joy
 /**
  * Class implementing a basic Joy -> Twist translation.
  */
-class TeleopTwistJoy
+class TeleopTwistJoy : public rclcpp::Node
 {
 public:
-  TeleopTwistJoy(rclcpp::Node::SharedPtr & node);
+  TeleopTwistJoy();
+
+  virtual ~TeleopTwistJoy();
 
 private:
   struct Impl;

--- a/package.xml
+++ b/package.xml
@@ -10,7 +10,7 @@
   <url type="website">http://wiki.ros.org/teleop_twist_joy</url>
   <author email="mpurvis@clearpathrobotics.com">Mike Purvis</author>
 
-  <buildtool_depend>ament_cmake_ros</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>geometry_msgs</depend>
   <depend>rclcpp</depend>

--- a/src/teleop_node.cpp
+++ b/src/teleop_node.cpp
@@ -23,6 +23,8 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCL
 ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+#include <memory>
+
 #include <rclcpp/rclcpp.hpp>
 
 #include "teleop_twist_joy/teleop_twist_joy.h"
@@ -31,11 +33,7 @@ int main(int argc, char *argv[])
 {
   rclcpp::init(argc, argv);
 
-  rclcpp::Node::SharedPtr node = rclcpp::Node::make_shared("teleop_twist_joy_node");
-
-  teleop_twist_joy::TeleopTwistJoy joy_teleop(node);
-
-  rclcpp::spin(node);
+  rclcpp::spin(std::make_unique<teleop_twist_joy::TeleopTwistJoy>());
 
   rclcpp::shutdown();
 

--- a/src/teleop_twist_joy.cpp
+++ b/src/teleop_twist_joy.cpp
@@ -51,13 +51,13 @@ struct TeleopTwistJoy::Impl
   rclcpp::Subscription<sensor_msgs::msg::Joy>::SharedPtr joy_sub;
   rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr cmd_vel_pub;
 
-  int enable_button;
-  int enable_turbo_button;
+  int64_t enable_button;
+  int64_t enable_turbo_button;
 
-  std::map<std::string, int> axis_linear_map;
+  std::map<std::string, int64_t> axis_linear_map;
   std::map<std::string, std::map<std::string, double>> scale_linear_map;
 
-  std::map<std::string, int> axis_angular_map;
+  std::map<std::string, int64_t> axis_angular_map;
   std::map<std::string, std::map<std::string, double>> scale_angular_map;
 
   bool sent_disable_msg;
@@ -76,8 +76,8 @@ TeleopTwistJoy::TeleopTwistJoy() : Node("teleop_twist_joy_node")
     std::bind(&TeleopTwistJoy::Impl::joyCallback, this->pimpl_, std::placeholders::_1),
     rmw_qos_profile_default);
 
-  this->get_parameter_or_set("enable_button", pimpl_->enable_button, 5);
-  this->get_parameter_or_set("enable_turbo_button", pimpl_->enable_turbo_button, -1);
+  this->get_parameter_or_set("enable_button", pimpl_->enable_button, 5L);
+  this->get_parameter_or_set("enable_turbo_button", pimpl_->enable_turbo_button, -1L);
   this->get_parameters("axis_linear", pimpl_->axis_linear_map);
   if (pimpl_->axis_linear_map.count("x") == 0)
   {
@@ -119,7 +119,7 @@ TeleopTwistJoy::TeleopTwistJoy() : Node("teleop_twist_joy_node")
   ROS_INFO_COND_NAMED(pimpl_->enable_turbo_button >= 0, "TeleopTwistJoy",
     "Turbo on button %i.", pimpl_->enable_turbo_button);
 
-  for (std::map<std::string, int>::iterator it = pimpl_->axis_linear_map.begin();
+  for (std::map<std::string, int64_t>::iterator it = pimpl_->axis_linear_map.begin();
        it != pimpl_->axis_linear_map.end(); ++it)
   {
     ROS_INFO_NAMED("TeleopTwistJoy", "Linear axis %s on %i at scale %f.",
@@ -128,7 +128,7 @@ TeleopTwistJoy::TeleopTwistJoy() : Node("teleop_twist_joy_node")
       "Turbo for linear axis %s is scale %f.", it->first.c_str(), pimpl_->scale_linear_map["turbo"][it->first]);
   }
 
-  for (std::map<std::string, int>::iterator it = pimpl_->axis_angular_map.begin();
+  for (std::map<std::string, int64_t>::iterator it = pimpl_->axis_angular_map.begin();
        it != pimpl_->axis_angular_map.end(); ++it)
   {
     ROS_INFO_NAMED("TeleopTwistJoy", "Angular axis %s on %i at scale %f.",
@@ -145,7 +145,7 @@ TeleopTwistJoy::~TeleopTwistJoy()
   delete pimpl_;
 }
 
-double getVal(const sensor_msgs::msg::Joy::SharedPtr joy_msg, const std::map<std::string, int>& axis_map,
+double getVal(const sensor_msgs::msg::Joy::SharedPtr joy_msg, const std::map<std::string, int64_t>& axis_map,
               const std::map<std::string, double>& scale_map, const std::string& fieldname)
 {
   if (axis_map.find(fieldname) == axis_map.end() ||

--- a/src/teleop_twist_joy.cpp
+++ b/src/teleop_twist_joy.cpp
@@ -76,8 +76,8 @@ TeleopTwistJoy::TeleopTwistJoy() : Node("teleop_twist_joy_node")
     std::bind(&TeleopTwistJoy::Impl::joyCallback, this->pimpl_, std::placeholders::_1),
     rmw_qos_profile_default);
 
-  this->get_parameter_or_set("enable_button", pimpl_->enable_button, 5L);
-  this->get_parameter_or_set("enable_turbo_button", pimpl_->enable_turbo_button, -1L);
+  this->get_parameter_or_set<int64_t>("enable_button", pimpl_->enable_button, 5L);
+  this->get_parameter_or_set<int64_t>("enable_turbo_button", pimpl_->enable_turbo_button, -1L);
   this->get_parameters("axis_linear", pimpl_->axis_linear_map);
   if (pimpl_->axis_linear_map.count("x") == 0)
   {

--- a/src/teleop_twist_joy.cpp
+++ b/src/teleop_twist_joy.cpp
@@ -22,13 +22,11 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCL
 ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include "teleop_twist_joy/teleop_twist_joy.h"
-
 #include <geometry_msgs/msg/twist.hpp>
 #include <rcutils/logging_macros.h>
 #include <sensor_msgs/msg/joy.hpp>
+#include "teleop_twist_joy/teleop_twist_joy.h"
 
-#include <functional>
 #include <map>
 #include <string>
 
@@ -47,8 +45,8 @@ struct TeleopTwistJoy::Impl
 {
   void joyCallback(const sensor_msgs::msg::Joy::SharedPtr joy);
 
-  rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr cmd_vel_pub;
   rclcpp::Subscription<sensor_msgs::msg::Joy>::SharedPtr joy_sub;
+  rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr cmd_vel_pub;
 
   int enable_button;
   int enable_turbo_button;
@@ -69,7 +67,7 @@ struct TeleopTwistJoy::Impl
  */
 TeleopTwistJoy::TeleopTwistJoy() : Node("teleop_twist_joy_node")
 {
-  pimpl_ = new Impl();
+  pimpl_ = new Impl;
 
   pimpl_->cmd_vel_pub = this->create_publisher<geometry_msgs::msg::Twist>("cmd_vel",
     rmw_qos_profile_sensor_data);
@@ -78,7 +76,7 @@ TeleopTwistJoy::TeleopTwistJoy() : Node("teleop_twist_joy_node")
     rmw_qos_profile_sensor_data);
 
   pimpl_->enable_button = 5;
-  this->get_parameter("enable_button", pimpl_->enable_button);
+  this->get_parameter_or("enable_button", pimpl_->enable_button, 5);
 
   pimpl_->enable_turbo_button = -1;
   this->get_parameter("enable_turbo_button", pimpl_->enable_turbo_button);
@@ -151,15 +149,8 @@ TeleopTwistJoy::~TeleopTwistJoy()
 
 void TeleopTwistJoy::Impl::joyCallback(const sensor_msgs::msg::Joy::SharedPtr joy_msg)
 {
+  // Initializes with zeros by default.
   auto cmd_vel_msg = std::make_shared<geometry_msgs::msg::Twist>();
-
-  cmd_vel_msg->linear.x = 0.0;
-  cmd_vel_msg->linear.y = 0.0;
-  cmd_vel_msg->linear.z = 0.0;
-
-  cmd_vel_msg->angular.x = 0.0;
-  cmd_vel_msg->angular.y = 0.0;
-  cmd_vel_msg->angular.z = 0.0;
 
   if (enable_turbo_button >= 0 && joy_msg->buttons[enable_turbo_button])
   {

--- a/src/teleop_twist_joy.cpp
+++ b/src/teleop_twist_joy.cpp
@@ -27,7 +27,9 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 #include <sensor_msgs/msg/joy.hpp>
 #include "teleop_twist_joy/teleop_twist_joy.h"
 
+#include <functional>
 #include <map>
+#include <memory>
 #include <string>
 
 #define ROS_INFO_NAMED RCUTILS_LOG_INFO_NAMED
@@ -44,6 +46,7 @@ namespace teleop_twist_joy
 struct TeleopTwistJoy::Impl
 {
   void joyCallback(const sensor_msgs::msg::Joy::SharedPtr joy);
+  void sendCmdVelMsg(const sensor_msgs::msg::Joy::SharedPtr, const std::string& which_map);
 
   rclcpp::Subscription<sensor_msgs::msg::Joy>::SharedPtr joy_sub;
   rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr cmd_vel_pub;
@@ -52,12 +55,10 @@ struct TeleopTwistJoy::Impl
   int enable_turbo_button;
 
   std::map<std::string, int> axis_linear_map;
-  std::map<std::string, double> scale_linear_map;
-  std::map<std::string, double> scale_linear_turbo_map;
+  std::map<std::string, std::map<std::string, double>> scale_linear_map;
 
   std::map<std::string, int> axis_angular_map;
-  std::map<std::string, double> scale_angular_map;
-  std::map<std::string, double> scale_angular_turbo_map;
+  std::map<std::string, std::map<std::string, double>> scale_angular_map;
 
   bool sent_disable_msg;
 };
@@ -70,73 +71,70 @@ TeleopTwistJoy::TeleopTwistJoy() : Node("teleop_twist_joy_node")
   pimpl_ = new Impl;
 
   pimpl_->cmd_vel_pub = this->create_publisher<geometry_msgs::msg::Twist>("cmd_vel",
-    rmw_qos_profile_sensor_data);
+    rmw_qos_profile_default);
   pimpl_->joy_sub = this->create_subscription<sensor_msgs::msg::Joy>("joy",
     std::bind(&TeleopTwistJoy::Impl::joyCallback, this->pimpl_, std::placeholders::_1),
-    rmw_qos_profile_sensor_data);
+    rmw_qos_profile_default);
 
-  pimpl_->enable_button = 5;
-  this->get_parameter_or("enable_button", pimpl_->enable_button, 5);
-
-  pimpl_->enable_turbo_button = -1;
-  this->get_parameter("enable_turbo_button", pimpl_->enable_turbo_button);
-
-  // TODO(clalancette): node->get_parameter(s) doesn't seem to
-  // support getting a map of values yet.  Revisit this once it does.
-  // if (nh_param->getParam("axis_linear", pimpl_->axis_linear_map))
-  // {
-  //   nh_param->getParam("axis_linear", pimpl_->axis_linear_map);
-  //   nh_param->getParam("scale_linear", pimpl_->scale_linear_map);
-  //   nh_param->getParam("scale_linear_turbo", pimpl_->scale_linear_turbo_map);
-  // }
-  // else
+  this->get_parameter_or_set("enable_button", pimpl_->enable_button, 5);
+  this->get_parameter_or_set("enable_turbo_button", pimpl_->enable_turbo_button, -1);
+  this->get_parameters("axis_linear", pimpl_->axis_linear_map);
+  if (pimpl_->axis_linear_map.count("x") == 0)
   {
     pimpl_->axis_linear_map["x"] = 5;
-    this->get_parameter("axis_linear", pimpl_->axis_linear_map["x"]);
-    pimpl_->scale_linear_map["x"] = 0.5;
-    this->get_parameter("scale_linear", pimpl_->scale_linear_map["x"]);
-    pimpl_->scale_linear_turbo_map["x"] = 1.0;
-    this->get_parameter("scale_linear_turbo", pimpl_->scale_linear_turbo_map["x"]);
+    this->set_parameter_if_not_set("axis_linear.x", pimpl_->axis_linear_map["x"]);
   }
-
-  // TODO(clalancette): node->get_parameter(s) doesn't seem to
-  // support getting a map of values yet.  Revisit this once it does.
-  // if (nh_param->getParam("axis_angular", pimpl_->axis_angular_map))
-  // {
-  //   nh_param->getParam("axis_angular", pimpl_->axis_angular_map);
-  //   nh_param->getParam("scale_angular", pimpl_->scale_angular_map);
-  //   nh_param->getParam("scale_angular_turbo", pimpl_->scale_angular_turbo_map);
-  // }
-  // else
+  this->get_parameters("axis_angular", pimpl_->axis_angular_map);
+  if (pimpl_->axis_angular_map.count("yaw") == 0)
   {
     pimpl_->axis_angular_map["yaw"] = 2;
-    this->get_parameter("axis_angular", pimpl_->axis_angular_map["yaw"]);
-    pimpl_->scale_angular_map["yaw"] = 0.5;
-    this->get_parameter("scale_angular", pimpl_->scale_angular_map["yaw"]);
-    pimpl_->scale_angular_turbo_map["yaw"] = pimpl_->scale_angular_map["yaw"];
-    this->get_parameter("scale_angular_turbo", pimpl_->scale_angular_turbo_map["yaw"]);
+    this->set_parameter_if_not_set("axis_angular.yaw", pimpl_->axis_angular_map["yaw"]);
+  }
+  this->get_parameters("scale_linear", pimpl_->scale_linear_map["normal"]);
+  if (pimpl_->scale_linear_map["normal"].count("x") == 0)
+  {
+    pimpl_->scale_linear_map["normal"]["x"] = 0.5;
+    this->set_parameter_if_not_set("scale_linear.x", pimpl_->scale_linear_map["normal"]["x"]);
+  }
+  this->get_parameters("scale_linear_turbo", pimpl_->scale_linear_map["turbo"]);
+  if (pimpl_->scale_linear_map["turbo"].count("x") == 0)
+  {
+    pimpl_->scale_linear_map["turbo"]["x"] = 1.0;
+    this->set_parameter_if_not_set("scale_linear_turbo.x", pimpl_->scale_linear_map["turbo"]["x"]);
+  }
+  this->get_parameters("scale_angular", pimpl_->scale_angular_map["normal"]);
+  if (pimpl_->scale_angular_map["normal"].count("yaw") == 0)
+  {
+    pimpl_->scale_angular_map["normal"]["yaw"] = 0.5;
+    this->set_parameter_if_not_set("scale_angular.yaw", pimpl_->scale_angular_map["normal"]["yaw"]);
+  }
+  this->get_parameters("scale_angular_turbo", pimpl_->scale_angular_map["turbo"]);
+  if (pimpl_->scale_angular_map["turbo"].count("yaw") == 0)
+  {
+    pimpl_->scale_angular_map["turbo"]["yaw"] = 1.0;
+    this->set_parameter_if_not_set("scale_angular_turbo.yaw", pimpl_->scale_angular_map["turbo"]["yaw"]);
   }
 
   ROS_INFO_NAMED("TeleopTwistJoy", "Teleop enable button %i.", pimpl_->enable_button);
   ROS_INFO_COND_NAMED(pimpl_->enable_turbo_button >= 0, "TeleopTwistJoy",
-      "Turbo on button %i.", pimpl_->enable_turbo_button);
+    "Turbo on button %i.", pimpl_->enable_turbo_button);
 
   for (std::map<std::string, int>::iterator it = pimpl_->axis_linear_map.begin();
-      it != pimpl_->axis_linear_map.end(); ++it)
+       it != pimpl_->axis_linear_map.end(); ++it)
   {
     ROS_INFO_NAMED("TeleopTwistJoy", "Linear axis %s on %i at scale %f.",
-    it->first.c_str(), it->second, pimpl_->scale_linear_map[it->first]);
+      it->first.c_str(), it->second, pimpl_->scale_linear_map["normal"][it->first]);
     ROS_INFO_COND_NAMED(pimpl_->enable_turbo_button >= 0, "TeleopTwistJoy",
-        "Turbo for linear axis %s is scale %f.", it->first.c_str(), pimpl_->scale_linear_turbo_map[it->first]);
+      "Turbo for linear axis %s is scale %f.", it->first.c_str(), pimpl_->scale_linear_map["turbo"][it->first]);
   }
 
   for (std::map<std::string, int>::iterator it = pimpl_->axis_angular_map.begin();
-      it != pimpl_->axis_angular_map.end(); ++it)
+       it != pimpl_->axis_angular_map.end(); ++it)
   {
     ROS_INFO_NAMED("TeleopTwistJoy", "Angular axis %s on %i at scale %f.",
-    it->first.c_str(), it->second, pimpl_->scale_angular_map[it->first]);
+      it->first.c_str(), it->second, pimpl_->scale_angular_map["normal"][it->first]);
     ROS_INFO_COND_NAMED(pimpl_->enable_turbo_button >= 0, "TeleopTwistJoy",
-        "Turbo for angular axis %s is scale %f.", it->first.c_str(), pimpl_->scale_angular_turbo_map[it->first]);
+      "Turbo for angular axis %s is scale %f.", it->first.c_str(), pimpl_->scale_angular_map["turbo"][it->first]);
   }
 
   pimpl_->sent_disable_msg = false;
@@ -147,70 +145,48 @@ TeleopTwistJoy::~TeleopTwistJoy()
   delete pimpl_;
 }
 
-void TeleopTwistJoy::Impl::joyCallback(const sensor_msgs::msg::Joy::SharedPtr joy_msg)
+double getVal(const sensor_msgs::msg::Joy::SharedPtr joy_msg, const std::map<std::string, int>& axis_map,
+              const std::map<std::string, double>& scale_map, const std::string& fieldname)
+{
+  if (axis_map.find(fieldname) == axis_map.end() ||
+      scale_map.find(fieldname) == scale_map.end() ||
+      static_cast<int>(joy_msg->axes.size()) <= axis_map.at(fieldname))
+  {
+    return 0.0;
+  }
+
+  return joy_msg->axes[axis_map.at(fieldname)] * scale_map.at(fieldname);
+}
+
+void TeleopTwistJoy::Impl::sendCmdVelMsg(const sensor_msgs::msg::Joy::SharedPtr joy_msg,
+                                         const std::string& which_map)
 {
   // Initializes with zeros by default.
   auto cmd_vel_msg = std::make_shared<geometry_msgs::msg::Twist>();
 
-  if (enable_turbo_button >= 0 && joy_msg->buttons[enable_turbo_button])
-  {
-    if (axis_linear_map.find("x") != axis_linear_map.end())
-    {
-      cmd_vel_msg->linear.x = joy_msg->axes[axis_linear_map["x"]] * scale_linear_turbo_map["x"];
-    }
-    if (axis_linear_map.find("y") != axis_linear_map.end())
-    {
-      cmd_vel_msg->linear.y = joy_msg->axes[axis_linear_map["y"]] * scale_linear_turbo_map["y"];
-    }
-    if  (axis_linear_map.find("z") != axis_linear_map.end())
-    {
-      cmd_vel_msg->linear.z = joy_msg->axes[axis_linear_map["z"]] * scale_linear_turbo_map["z"];
-    }
-    if  (axis_angular_map.find("yaw") != axis_angular_map.end())
-    {
-      cmd_vel_msg->angular.z = joy_msg->axes[axis_angular_map["yaw"]] * scale_angular_turbo_map["yaw"];
-    }
-    if  (axis_angular_map.find("pitch") != axis_angular_map.end())
-    {
-      cmd_vel_msg->angular.y = joy_msg->axes[axis_angular_map["pitch"]] * scale_angular_turbo_map["pitch"];
-    }
-    if  (axis_angular_map.find("roll") != axis_angular_map.end())
-    {
-      cmd_vel_msg->angular.x = joy_msg->axes[axis_angular_map["roll"]] * scale_angular_turbo_map["roll"];
-    }
+  cmd_vel_msg->linear.x = getVal(joy_msg, axis_linear_map, scale_linear_map[which_map], "x");
+  cmd_vel_msg->linear.y = getVal(joy_msg, axis_linear_map, scale_linear_map[which_map], "y");
+  cmd_vel_msg->linear.z = getVal(joy_msg, axis_linear_map, scale_linear_map[which_map], "z");
+  cmd_vel_msg->angular.z = getVal(joy_msg, axis_angular_map, scale_angular_map[which_map], "yaw");
+  cmd_vel_msg->angular.y = getVal(joy_msg, axis_angular_map, scale_angular_map[which_map], "pitch");
+  cmd_vel_msg->angular.x = getVal(joy_msg, axis_angular_map, scale_angular_map[which_map], "roll");
 
-    cmd_vel_pub->publish(cmd_vel_msg);
-    sent_disable_msg = false;
+  cmd_vel_pub->publish(cmd_vel_msg);
+  sent_disable_msg = false;
+}
+
+void TeleopTwistJoy::Impl::joyCallback(const sensor_msgs::msg::Joy::SharedPtr joy_msg)
+{
+  if (enable_turbo_button >= 0 &&
+      static_cast<int>(joy_msg->buttons.size()) > enable_turbo_button &&
+      joy_msg->buttons[enable_turbo_button])
+  {
+    sendCmdVelMsg(joy_msg, "turbo");
   }
-  else if (joy_msg->buttons[enable_button])
+  else if (static_cast<int>(joy_msg->buttons.size()) > enable_button &&
+           joy_msg->buttons[enable_button])
   {
-    if  (axis_linear_map.find("x") != axis_linear_map.end())
-    {
-      cmd_vel_msg->linear.x = joy_msg->axes[axis_linear_map["x"]] * scale_linear_map["x"];
-    }
-    if  (axis_linear_map.find("y") != axis_linear_map.end())
-    {
-      cmd_vel_msg->linear.y = joy_msg->axes[axis_linear_map["y"]] * scale_linear_map["y"];
-    }
-    if  (axis_linear_map.find("z") != axis_linear_map.end())
-    {
-      cmd_vel_msg->linear.z = joy_msg->axes[axis_linear_map["z"]] * scale_linear_map["z"];
-    }
-    if  (axis_angular_map.find("yaw") != axis_angular_map.end())
-    {
-      cmd_vel_msg->angular.z = joy_msg->axes[axis_angular_map["yaw"]] * scale_angular_map["yaw"];
-    }
-    if  (axis_angular_map.find("pitch") != axis_angular_map.end())
-    {
-      cmd_vel_msg->angular.y = joy_msg->axes[axis_angular_map["pitch"]] * scale_angular_map["pitch"];
-    }
-    if  (axis_angular_map.find("roll") != axis_angular_map.end())
-    {
-      cmd_vel_msg->angular.x = joy_msg->axes[axis_angular_map["roll"]] * scale_angular_map["roll"];
-    }
-
-    cmd_vel_pub->publish(cmd_vel_msg);
-    sent_disable_msg = false;
+    sendCmdVelMsg(joy_msg, "normal");
   }
   else
   {
@@ -218,6 +194,8 @@ void TeleopTwistJoy::Impl::joyCallback(const sensor_msgs::msg::Joy::SharedPtr jo
     // in order to stop the robot.
     if (!sent_disable_msg)
     {
+      // Initializes with zeros by default.
+      auto cmd_vel_msg = std::make_shared<geometry_msgs::msg::Twist>();
       cmd_vel_pub->publish(cmd_vel_msg);
       sent_disable_msg = true;
     }


### PR DESCRIPTION
This PR aims to allow the teleop_twist_joy node to control the buttons being used for various things via parameters.  The commits roughly do the following:

1.  Rewrite the `TeleopTwistJoy` class to inherit from Node, which makes further changes easier.
1.  Synchronizes the ros2 branch a bit with upstream.
1.  Sets the parameters on the node.
1.  Implements param_change_callback to make sure parameter changes get synchronized from the parameters into the `Impl` class.

That last point deserves a bit more explanation.  The design choice I had was to either keep the `Impl` class as-is and synchronize changes from the parameters to it, or to make the Parameters the "backing store" for the axes and scales.  I ended up keeping things closer to how they are today, mostly to minimize change from upstream.

Finally, here is a diff between this PR and https://github.com/ros-teleop/teleop_twist_joy/commit/10d79bebbf112f95f32713895f7cd0668faa83fc: https://gist.github.com/clalancette/334c53df8d80c2cc820c75595243cfda