### PR TITLE
[Windows][dashing] Export interfaces for Shared Lib on Windows.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,11 @@ include_directories(include)
 
 add_library(${PROJECT_NAME} SHARED src/${PROJECT_NAME})
 
+include(GenerateExportHeader)
+generate_export_header(${PROJECT_NAME} EXPORT_FILE_NAME ${PROJECT_NAME}/${PROJECT_NAME}_export.h)
+target_include_directories(${PROJECT_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>")
+set_target_properties(${PROJECT_NAME} PROPERTIES EXPORT_HEADER_DIR "${CMAKE_CURRENT_BINARY_DIR}")
+
 ament_target_dependencies(${PROJECT_NAME}
   "geometry_msgs"
   "rclcpp"
@@ -46,6 +51,10 @@ install(TARGETS ${PROJECT_NAME}_node
 
 install(DIRECTORY include/
   DESTINATION include)
+
+install(FILES
+  ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}/${PROJECT_NAME}_export.h
+  DESTINATION include/${PROJECT_NAME})
 
 install(DIRECTORY launch config
   DESTINATION share/${PROJECT_NAME})

--- a/include/teleop_twist_joy/teleop_twist_joy.hpp
+++ b/include/teleop_twist_joy/teleop_twist_joy.hpp
@@ -26,6 +26,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 #define TELEOP_TWIST_JOY_TELEOP_TWIST_JOY_H
 
 #include <rclcpp/rclcpp.hpp>
+#include "teleop_twist_joy/teleop_twist_joy_export.h"
 
 namespace teleop_twist_joy
 {
@@ -33,7 +34,7 @@ namespace teleop_twist_joy
 /**
  * Class implementing a basic Joy -> Twist translation.
  */
-class TeleopTwistJoy : public rclcpp::Node
+class TELEOP_TWIST_JOY_EXPORT TeleopTwistJoy : public rclcpp::Node
 {
 public:
   explicit TeleopTwistJoy(const rclcpp::NodeOptions& options);


### PR DESCRIPTION
On Windows, for a shared library, the interfaces must be explicitly decorated by proper `dllimport` and `dllexport` usage. Otherwise, no imported library (.lib) will be generated for the downstream projects to consume at link time.

This pull request is to add the interface export in a portable way provided by `CMake` (instead of directly using MSVC specific `dllimport` and `dllexport`), so that it prevents from the link time errors like below on Windows\MSVC build:

```
Link:
  C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC\14.23.28105\bin\HostX64\x64\link.exe /ERRORREPORT:QUEUE /OUT:"C:\colcon_ws\build\teleop_twist_joy\Release\teleop_node.exe" /INCREMENTAL:NO /NOLOGO Release\teleop_twist_joy.lib C:\opt\rosdeps\x64\lib\PocoFoundation.lib iphlpapi.lib C:\opt\ros\dashing\x64\lib\console_bridge.lib C:\opt\ros\dashing\x64\Lib\class_loader.lib C:\opt\ros\dashing\x64\Lib\rclcpp.lib C:\opt\ros\dashing\x64\Lib\rcl.lib C:\opt\ros\dashing\x64\Lib\rcl_interfaces__rosidl_typesupport_c.lib C:\opt\ros\dashing\x64\Lib\rcl_interfaces__rosidl_typesupport_cpp.lib C:\opt\ros\dashing\x64\Lib\rcl_interfaces__rosidl_typesupport_fastrtps_c.lib C:\opt\ros\dashing\x64\Lib\rcl_interfaces__rosidl_generator_c.lib C:\opt\ros\dashing\x64\Lib\rcl_interfaces__rosidl_typesupport_fastrtps_cpp.lib C:\opt\ros\dashing\x64\Lib\rcl_interfaces__rosidl_typesupport_introspection_c.lib C:\opt\ros\dashing\x64\Lib\rcl_interfaces__rosidl_typesupport_introspection_cpp.lib C:\opt\ros\dashing\x64\Lib\rmw_implementation.lib C:\opt\ros\dashing\x64\Lib\rmw.lib C:\opt\ros\dashing\x64\Lib\rcutils.lib C:\opt\ros\dashing\x64\Lib\rcl_logging_noop.lib C:\opt\ros\dashing\x64\Lib\rosgraph_msgs__rosidl_generator_c.lib C:\opt\ros\dashing\x64\Lib\rosgraph_msgs__rosidl_typesupport_c.lib C:\opt\ros\dashing\x64\Lib\rosgraph_msgs__rosidl_typesupport_cpp.lib C:\opt\ros\dashing\x64\Lib\rosgraph_msgs__rosidl_typesupport_introspection_c.lib C:\opt\ros\dashing\x64\Lib\rosgraph_msgs__rosidl_typesupport_introspection_cpp.lib C:\opt\ros\dashing\x64\Lib\rosgraph_msgs__rosidl_typesupport_fastrtps_c.lib C:\opt\ros\dashing\x64\Lib\rosgraph_msgs__rosidl_typesupport_fastrtps_cpp.lib C:\opt\ros\dashing\x64\Lib\rcl_yaml_param_parser.lib C:\opt\ros\dashing\x64\Lib\geometry_msgs__rosidl_typesupport_c.lib C:\opt\ros\dashing\x64\Lib\geometry_msgs__rosidl_typesupport_cpp.lib C:\opt\ros\dashing\x64\Lib\geometry_msgs__rosidl_typesupport_fastrtps_c.lib C:\opt\ros\dashing\x64\Lib\geometry_msgs__rosidl_generator_c.lib C:\opt\ros\dashing\x64\Lib\geometry_msgs__rosidl_typesupport_fastrtps_cpp.lib C:\opt\ros\dashing\x64\Lib\geometry_msgs__rosidl_typesupport_introspection_c.lib C:\opt\ros\dashing\x64\Lib\geometry_msgs__rosidl_typesupport_introspection_cpp.lib C:\opt\ros\dashing\x64\Lib\builtin_interfaces__rosidl_typesupport_c.lib C:\opt\ros\dashing\x64\Lib\builtin_interfaces__rosidl_typesupport_cpp.lib C:\opt\ros\dashing\x64\Lib\builtin_interfaces__rosidl_typesupport_fastrtps_c.lib C:\opt\ros\dashing\x64\Lib\builtin_interfaces__rosidl_generator_c.lib C:\opt\ros\dashing\x64\Lib\builtin_interfaces__rosidl_typesupport_fastrtps_cpp.lib C:\opt\ros\dashing\x64\Lib\builtin_interfaces__rosidl_typesupport_introspection_c.lib C:\opt\ros\dashing\x64\Lib\builtin_interfaces__rosidl_typesupport_introspection_cpp.lib C:\opt\ros\dashing\x64\Lib\std_msgs__rosidl_generator_c.lib C:\opt\ros\dashing\x64\Lib\std_msgs__rosidl_typesupport_c.lib C:\opt\ros\dashing\x64\Lib\std_msgs__rosidl_typesupport_cpp.lib C:\opt\ros\dashing\x64\Lib\std_msgs__rosidl_typesupport_introspection_c.lib C:\opt\ros\dashing\x64\Lib\std_msgs__rosidl_typesupport_introspection_cpp.lib C:\opt\ros\dashing\x64\Lib\std_msgs__rosidl_typesupport_fastrtps_c.lib C:\opt\ros\dashing\x64\Lib\std_msgs__rosidl_typesupport_fastrtps_cpp.lib C:\opt\ros\dashing\x64\Lib\rosidl_typesupport_c.lib C:\opt\ros\dashing\x64\Lib\rosidl_typesupport_cpp.lib C:\opt\ros\dashing\x64\Lib\rosidl_generator_c.lib C:\opt\ros\dashing\x64\Lib\rosidl_typesupport_introspection_c.lib C:\opt\ros\dashing\x64\Lib\rosidl_typesupport_introspection_cpp.lib C:\opt\ros\dashing\x64\Lib\sensor_msgs__rosidl_generator_c.lib C:\opt\ros\dashing\x64\Lib\sensor_msgs__rosidl_typesupport_c.lib C:\opt\ros\dashing\x64\Lib\sensor_msgs__rosidl_typesupport_cpp.lib C:\opt\ros\dashing\x64\Lib\sensor_msgs__rosidl_typesupport_introspection_c.lib C:\opt\ros\dashing\x64\Lib\sensor_msgs__rosidl_typesupport_introspection_cpp.lib C:\opt\ros\dashing\x64\Lib\sensor_msgs__rosidl_typesupport_fastrtps_c.lib C:\opt\ros\dashing\x64\Lib\sensor_msgs__rosidl_typesupport_fastrtps_cpp.lib kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdlg32.lib advapi32.lib /MANIFEST /MANIFESTUAC:"level='asInvoker' uiAccess='false'" /manifest:embed /PDB:"C:/colcon_ws/build/teleop_twist_joy/Release/teleop_node.pdb" /SUBSYSTEM:CONSOLE /TLBID:1 /DYNAMICBASE /NXCOMPAT /IMPLIB:"C:/colcon_ws/build/teleop_twist_joy/Release/teleop_node.lib" /MACHINE:X64  /machine:x64 teleop_twist_joy_node.dir\Release\teleop_node.obj
LINK : fatal error LNK1181: cannot open input file 'Release\teleop_twist_joy.lib' [C:\colcon_ws\build\teleop_twist_joy\teleop_twist_joy_node.vcxproj]
Done Building Project "C:\colcon_ws\build\teleop_twist_joy\teleop_twist_joy_node.vcxproj" (default targets) -- FAILED.
Done Building Project "C:\colcon_ws\build\teleop_twist_joy\ALL_BUILD.vcxproj" (default targets) -- FAILED.

Build FAILED.

"C:\colcon_ws\build\teleop_twist_joy\ALL_BUILD.vcxproj" (default target) (1) ->
"C:\colcon_ws\build\teleop_twist_joy\teleop_twist_joy_node.vcxproj" (default target) (4) ->
(Link target) -> 
  LINK : fatal error LNK1181: cannot open input file 'Release\teleop_twist_joy.lib' [C:\colcon_ws\build\teleop_twist_joy\teleop_twist_joy_node.vcxproj]

    0 Warning(s)
    1 Error(s)

Time Elapsed 00:00:10.49
```