### PR TITLE
Stop using launch features deprecated in Foxy

### DIFF
--- a/test/differential_joy_launch_test.py
+++ b/test/differential_joy_launch_test.py
@@ -1,6 +1,6 @@
 import launch
-import launch_ros
 import launch_ros.actions
+import launch_testing
 
 import pytest
 
@@ -8,7 +8,7 @@ import test_joy_twist
 
 
 @pytest.mark.rostest
-def generate_test_description(ready_fn):
+def generate_test_description():
     teleop_node = launch_ros.actions.Node(
         package='teleop_twist_joy',
         executable='teleop_node',
@@ -21,12 +21,10 @@ def generate_test_description(ready_fn):
         }],
     )
 
-    return (
-        launch.LaunchDescription([
+    return launch.LaunchDescription([
             teleop_node,
-            launch.actions.OpaqueFunction(function=lambda context: ready_fn()),
+            launch_testing.actions.ReadyToTest(),
         ]), locals()
-    )
 
 
 class DifferentialJoy(test_joy_twist.TestJoyTwist):

--- a/test/differential_joy_launch_test.py
+++ b/test/differential_joy_launch_test.py
@@ -11,7 +11,7 @@ import test_joy_twist
 def generate_test_description(ready_fn):
     teleop_node = launch_ros.actions.Node(
         package='teleop_twist_joy',
-        node_executable='teleop_node',
+        executable='teleop_node',
         parameters=[{
             'axis_linear.x': 1,
             'axis_angular.yaw': 0,

--- a/test/holonomic_joy_launch_test.py
+++ b/test/holonomic_joy_launch_test.py
@@ -11,7 +11,7 @@ import test_joy_twist
 def generate_test_description(ready_fn):
     teleop_node = launch_ros.actions.Node(
         package='teleop_twist_joy',
-        node_executable='teleop_node',
+        executable='teleop_node',
         parameters=[{
             'axis_linear.x': 1,
             'axis_linear.y': 2,

--- a/test/holonomic_joy_launch_test.py
+++ b/test/holonomic_joy_launch_test.py
@@ -1,6 +1,6 @@
 import launch
-import launch_ros
 import launch_ros.actions
+import launch_testing
 
 import pytest
 
@@ -8,7 +8,7 @@ import test_joy_twist
 
 
 @pytest.mark.rostest
-def generate_test_description(ready_fn):
+def generate_test_description():
     teleop_node = launch_ros.actions.Node(
         package='teleop_twist_joy',
         executable='teleop_node',
@@ -23,12 +23,10 @@ def generate_test_description(ready_fn):
         }],
     )
 
-    return (
-        launch.LaunchDescription([
+    return launch.LaunchDescription([
             teleop_node,
-            launch.actions.OpaqueFunction(function=lambda context: ready_fn()),
+            launch_testing.actions.ReadyToTest(),
         ]), locals()
-    )
 
 
 class HolonomicJoy(test_joy_twist.TestJoyTwist):

--- a/test/no_enable_joy_launch_test.py
+++ b/test/no_enable_joy_launch_test.py
@@ -1,6 +1,6 @@
 import launch
-import launch_ros
 import launch_ros.actions
+import launch_testing
 
 import pytest
 
@@ -8,7 +8,7 @@ import test_joy_twist
 
 
 @pytest.mark.rostest
-def generate_test_description(ready_fn):
+def generate_test_description():
     teleop_node = launch_ros.actions.Node(
         package='teleop_twist_joy',
         executable='teleop_node',
@@ -21,12 +21,10 @@ def generate_test_description(ready_fn):
         }],
     )
 
-    return (
-        launch.LaunchDescription([
+    return launch.LaunchDescription([
             teleop_node,
-            launch.actions.OpaqueFunction(function=lambda context: ready_fn()),
+            launch_testing.actions.ReadyToTest(),
         ]), locals()
-    )
 
 
 class NoEnableJoy(test_joy_twist.TestJoyTwist):

--- a/test/no_enable_joy_launch_test.py
+++ b/test/no_enable_joy_launch_test.py
@@ -11,7 +11,7 @@ import test_joy_twist
 def generate_test_description(ready_fn):
     teleop_node = launch_ros.actions.Node(
         package='teleop_twist_joy',
-        node_executable='teleop_node',
+        executable='teleop_node',
         parameters=[{
             'axis_linear.x': 1,
             'axis_angular.yaw': 0,

--- a/test/only_turbo_joy_launch_test.py
+++ b/test/only_turbo_joy_launch_test.py
@@ -1,6 +1,6 @@
 import launch
-import launch_ros
 import launch_ros.actions
+import launch_testing
 
 import pytest
 
@@ -8,7 +8,7 @@ import test_joy_twist
 
 
 @pytest.mark.rostest
-def generate_test_description(ready_fn):
+def generate_test_description():
     teleop_node = launch_ros.actions.Node(
         package='teleop_twist_joy',
         executable='teleop_node',
@@ -24,12 +24,10 @@ def generate_test_description(ready_fn):
         }],
     )
 
-    return (
-        launch.LaunchDescription([
+    return launch.LaunchDescription([
             teleop_node,
-            launch.actions.OpaqueFunction(function=lambda context: ready_fn()),
+            launch_testing.actions.ReadyToTest(),
         ]), locals()
-    )
 
 
 class OnlyTurboJoy(test_joy_twist.TestJoyTwist):

--- a/test/only_turbo_joy_launch_test.py
+++ b/test/only_turbo_joy_launch_test.py
@@ -11,7 +11,7 @@ import test_joy_twist
 def generate_test_description(ready_fn):
     teleop_node = launch_ros.actions.Node(
         package='teleop_twist_joy',
-        node_executable='teleop_node',
+        executable='teleop_node',
         parameters=[{
             'axis_linear.x': 1,
             'axis_angular.yaw': 0,

--- a/test/six_dof_joy_launch_test.py
+++ b/test/six_dof_joy_launch_test.py
@@ -1,6 +1,6 @@
 import launch
-import launch_ros
 import launch_ros.actions
+import launch_testing
 
 import pytest
 
@@ -8,7 +8,7 @@ import test_joy_twist
 
 
 @pytest.mark.rostest
-def generate_test_description(ready_fn):
+def generate_test_description():
     teleop_node = launch_ros.actions.Node(
         package='teleop_twist_joy',
         executable='teleop_node',
@@ -29,12 +29,10 @@ def generate_test_description(ready_fn):
         }],
     )
 
-    return (
-        launch.LaunchDescription([
+    return launch.LaunchDescription([
             teleop_node,
-            launch.actions.OpaqueFunction(function=lambda context: ready_fn()),
+            launch_testing.actions.ReadyToTest(),
         ]), locals()
-    )
 
 
 class SixDofJoy(test_joy_twist.TestJoyTwist):

--- a/test/six_dof_joy_launch_test.py
+++ b/test/six_dof_joy_launch_test.py
@@ -11,7 +11,7 @@ import test_joy_twist
 def generate_test_description(ready_fn):
     teleop_node = launch_ros.actions.Node(
         package='teleop_twist_joy',
-        node_executable='teleop_node',
+        executable='teleop_node',
         parameters=[{
             'axis_linear.x': 1,
             'axis_linear.y': 2,

--- a/test/turbo_angular_enable_joy_launch_test.py
+++ b/test/turbo_angular_enable_joy_launch_test.py
@@ -1,6 +1,6 @@
 import launch
-import launch_ros
 import launch_ros.actions
+import launch_testing
 
 import pytest
 
@@ -8,7 +8,7 @@ import test_joy_twist
 
 
 @pytest.mark.rostest
-def generate_test_description(ready_fn):
+def generate_test_description():
     teleop_node = launch_ros.actions.Node(
         package='teleop_twist_joy',
         executable='teleop_node',
@@ -24,12 +24,10 @@ def generate_test_description(ready_fn):
         }],
     )
 
-    return (
-        launch.LaunchDescription([
+    return launch.LaunchDescription([
             teleop_node,
-            launch.actions.OpaqueFunction(function=lambda context: ready_fn()),
+            launch_testing.actions.ReadyToTest(),
         ]), locals()
-    )
 
 
 class TurboAngularEnableJoy(test_joy_twist.TestJoyTwist):

--- a/test/turbo_angular_enable_joy_launch_test.py
+++ b/test/turbo_angular_enable_joy_launch_test.py
@@ -11,7 +11,7 @@ import test_joy_twist
 def generate_test_description(ready_fn):
     teleop_node = launch_ros.actions.Node(
         package='teleop_twist_joy',
-        node_executable='teleop_node',
+        executable='teleop_node',
         parameters=[{
             'axis_linear.x': 1,
             'axis_angular.yaw': 0,

--- a/test/turbo_enable_joy_launch_test.py
+++ b/test/turbo_enable_joy_launch_test.py
@@ -1,6 +1,6 @@
 import launch
-import launch_ros
 import launch_ros.actions
+import launch_testing
 
 import pytest
 
@@ -8,7 +8,7 @@ import test_joy_twist
 
 
 @pytest.mark.rostest
-def generate_test_description(ready_fn):
+def generate_test_description():
     teleop_node = launch_ros.actions.Node(
         package='teleop_twist_joy',
         executable='teleop_node',
@@ -24,12 +24,10 @@ def generate_test_description(ready_fn):
         }],
     )
 
-    return (
-        launch.LaunchDescription([
+    return launch.LaunchDescription([
             teleop_node,
-            launch.actions.OpaqueFunction(function=lambda context: ready_fn()),
+            launch_testing.actions.ReadyToTest(),
         ]), locals()
-    )
 
 
 class TurboEnableJoy(test_joy_twist.TestJoyTwist):

--- a/test/turbo_enable_joy_launch_test.py
+++ b/test/turbo_enable_joy_launch_test.py
@@ -11,7 +11,7 @@ import test_joy_twist
 def generate_test_description(ready_fn):
     teleop_node = launch_ros.actions.Node(
         package='teleop_twist_joy',
-        node_executable='teleop_node',
+        executable='teleop_node',
         parameters=[{
             'axis_linear.x': 1,
             'axis_angular.yaw': 0,


### PR DESCRIPTION
There are two things:

1.  Switch from `node_executable` -> `executable`
1.  Stop using `ready_fn` and switch to `ReadyToTest`.

There should be no functional change with either of these, it just gets rid of the warning messages when running the tests on Foxy.