### PR TITLE
Update README to reflect changes to config parameters. (fixes #23)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,15 +36,15 @@ The package comes with the `teleop_node` that republishes `sensor_msgs/msg/Joy` 
 
 - `scale_linear.<axis>`
   - Scale to apply to joystick linear axis for regular-speed movement.
-  - `axis_linear.x (double, default: 0.5)`
-  - `axis_linear.y (double, default: 0.0)`
-  - `axis_linear.z (double, default: 0.0)`
+  - `scale_linear.x (double, default: 0.5)`
+  - `scale_linear.y (double, default: 0.0)`
+  - `scale_linear.z (double, default: 0.0)`
 
 - `scale_linear_turbo.<axis>`
   - Scale to apply to joystick linear axis for high-speed movement.
-  - `axis_linear.x (double, default: 1.0)`
-  - `axis_linear.y (double, default: 0.0)`
-  - `axis_linear.z (double, default: 0.0)`
+  - `scale_linear_turbo.x (double, default: 1.0)`
+  - `scale_linear_turbo.y (double, default: 0.0)`
+  - `scale_linear_turbo.z (double, default: 0.0)`
 
 - `axis_angular.<axis>`
   - Joystick axis to use for angular movement control.
@@ -54,15 +54,15 @@ The package comes with the `teleop_node` that republishes `sensor_msgs/msg/Joy` 
   
 - `scale_angular.<axis>`
   - Scale to apply to joystick angular axis.
-  - `axis_angular.yaw (double, default: 0.5)`
-  - `axis_angular.pitch (double, default: 0.0)`
-  - `axis_angular.roll (double, default: 0.0)`
+  - `scale_angular.yaw (double, default: 0.5)`
+  - `scale_angular.pitch (double, default: 0.0)`
+  - `scale_angular.roll (double, default: 0.0)`
   
 - `scale_angular_turbo.<axis>`
   - Scale to apply to joystick angular axis for high-speed movement.
-  - `axis_angular.yaw (double, default: 1.0)`
-  - `axis_angular.pitch (double, default: 0.0)`
-  - `axis_angular.roll (double, default: 0.0)`
+  - `scale_angular_turbo.yaw (double, default: 1.0)`
+  - `scale_angular_turbo.pitch (double, default: 0.0)`
+  - `scale_angular_turbo.roll (double, default: 0.0)`
     
 
   

--- a/README.md
+++ b/README.md
@@ -19,12 +19,6 @@ The package comes with the `teleop_node` that republishes `sensor_msgs/msg/Joy` 
   - Command velocity messages arising from Joystick commands.
 
 ## Parameters
-- `axis_angular (int, default: 0)`
-  - Joystick axis to use for angular movement control.
-  
-- `axis_linear (int, default: 1)`
-  - Joystick axis to use for linear movement control.
-  
 - `require_enable_button (bool, default: true)`
   - Whether to require the enable button for enabling movement.
 
@@ -33,18 +27,46 @@ The package comes with the `teleop_node` that republishes `sensor_msgs/msg/Joy` 
   
 - `enable_turbo_button (int, default: -1)`
   - Joystick button to enable high-speed movement (disabled when -1).
-  
-- `scale_angular (double, default: 1.0)`
-  - Scale to apply to joystick angular axis.
-  
-- `scale_angluar_turbo (double, default: 1.0)`
-  - Scale to apply to joystick angular axis for high-speed movement.
-    
-- `scale_linear (double, default: 0.5)`
+
+- `axis_linear.<axis>`
+  - Joystick axis to use for linear movement control.
+  - `axis_linear.x (int, default: 5)`
+  - `axis_linear.y (int, default: -1)`
+  - `axis_linear.z (int, default: -1)`
+
+- `scale_linear.<axis>`
   - Scale to apply to joystick linear axis for regular-speed movement.
-  
-- `scale_linear_turbo (double, default: 1.0)`
+  - `axis_linear.x (double, default: 0.5)`
+  - `axis_linear.y (double, default: 0.0)`
+  - `axis_linear.z (double, default: 0.0)`
+
+- `scale_linear_turbo.<axis>`
   - Scale to apply to joystick linear axis for high-speed movement.
+  - `axis_linear.x (double, default: 1.0)`
+  - `axis_linear.y (double, default: 0.0)`
+  - `axis_linear.z (double, default: 0.0)`
+
+- `axis_angular.<axis>`
+  - Joystick axis to use for angular movement control.
+  - `axis_angular.yaw (int, default: 2)`
+  - `axis_angular.pitch (int, default: -1)`
+  - `axis_angular.roll (int, default: -1)`
+  
+- `scale_angular.<axis>`
+  - Scale to apply to joystick angular axis.
+  - `axis_angular.yaw (double, default: 0.5)`
+  - `axis_angular.pitch (double, default: 0.0)`
+  - `axis_angular.roll (double, default: 0.0)`
+  
+- `scale_angular_turbo.<axis>`
+  - Scale to apply to joystick angular axis for high-speed movement.
+  - `axis_angular.yaw (double, default: 1.0)`
+  - `axis_angular.pitch (double, default: 0.0)`
+  - `axis_angular.roll (double, default: 0.0)`
+    
+
+  
+
 
 # Usage
 


### PR DESCRIPTION
I have updated the README to reflect the new parameters, and the new defaults.

In doing so a few issues arose, some of which I have acted on and some I have left.

1. I've rearranged the overall order of the parameters to be a bit more natural (axis, scale, scale_turbo; linear then angular). This reflects how it has been written in the config files too (though not in the code itself).
2. Rather than making the parameter list three times as long with no clarity, I have grouped the parameters which are part of a struct. This was the simplest way I could think of to do it, please let me know if you have a better idea.
3. In doing the above, I have introduced some ambiguity with the word `axis` (to refer to motion/coordinate axes as well as joystick axes). I think this is an inevitable consequence of a program that maps from axis to axis, and is clear enough from context.
4. I think it would perhaps be clearer to order the angular axes as `roll,pitch,yaw` rather than `yaw,pitch,roll`. I presume this has arisen from the original one only having `x` and `yaw`, and the other axes being added later. But now that we can map to all six axes, it seems confusing to me that the order here is different from the order that you then see in the `Twist` message. I've opted **not** to change this yet in case there is a strong convention to favour `yaw,pitch,roll` that is more important, but if you agree then I'll reverse them.
5. On the above, is there value in replacing/adding parameters to reference the angular motions as `x/y/z`? I'm not sure what is clearer/more sensible.

