### PR TITLE
fix notation

### DIFF
--- a/launch/teleop-launch.py
+++ b/launch/teleop-launch.py
@@ -20,13 +20,13 @@ def generate_launch_description():
             joy_config, launch.substitutions.TextSubstitution(text='.config.yaml')]),
 
         launch_ros.actions.Node(
-            package='joy', node_executable='joy_node', name='joy_node',
+            package='joy', executable='joy_node', name='joy_node',
             parameters=[{
                 'dev': joy_dev,
                 'deadzone': 0.3,
                 'autorepeat_rate': 20.0,
             }]),
         launch_ros.actions.Node(
-            package='teleop_twist_joy', node_executable='teleop_node',
+            package='teleop_twist_joy', executable='teleop_node',
             name='teleop_twist_joy_node', parameters=[config_filepath]),
     ])


### PR DESCRIPTION
fix notation indicate executable file in launch.py
Actually I don't know this is the right notation, but I can;'t launch the file if I include the launch.py from other one.
probably the notation indicate executable file in launch.py was changed??
Warning messages are appeared if I use `node_excutable`
 