### PR TITLE
Fix the launch file to use 'executable'.

### DIFF
--- a/launch/teleop-launch.py
+++ b/launch/teleop-launch.py
@@ -20,13 +20,13 @@ def generate_launch_description():
             joy_config, launch.substitutions.TextSubstitution(text='.config.yaml')]),
 
         launch_ros.actions.Node(
-            package='joy', node_executable='joy_node', name='joy_node',
+            package='joy', executable='joy_node', name='joy_node',
             parameters=[{
                 'dev': joy_dev,
                 'deadzone': 0.3,
                 'autorepeat_rate': 20.0,
             }]),
         launch_ros.actions.Node(
-            package='teleop_twist_joy', node_executable='teleop_node',
+            package='teleop_twist_joy', executable='teleop_node',
             name='teleop_twist_joy_node', parameters=[config_filepath]),
     ])


### PR DESCRIPTION
'node_executable' is deprecated in Foxy and removed in Galactic.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Fixes #27 