### PR TITLE
Cleanups in the code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,13 @@ find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(sensor_msgs REQUIRED)
 
-add_library(${PROJECT_NAME} SHARED src/${PROJECT_NAME})
+add_library(${PROJECT_NAME} SHARED src/teleop_twist_joy.cpp)
+target_link_libraries(${PROJECT_NAME}
+  ${geometry_msgs_TARGETS}
+  rclcpp::rclcpp
+  rclcpp_components::component
+  ${sensor_msgs_TARGETS}
+)
 
 include(GenerateExportHeader)
 generate_export_header(${PROJECT_NAME} EXPORT_FILE_NAME ${PROJECT_NAME}/${PROJECT_NAME}_export.h)
@@ -26,13 +32,6 @@ target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
 set_target_properties(${PROJECT_NAME} PROPERTIES EXPORT_HEADER_DIR "${CMAKE_CURRENT_BINARY_DIR}")
-
-ament_target_dependencies(${PROJECT_NAME}
-  "geometry_msgs"
-  "rclcpp"
-  "rclcpp_components"
-  "sensor_msgs"
-)
 
 rclcpp_components_register_nodes(${PROJECT_NAME}
   "teleop_twist_joy::TeleopTwistJoy")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,8 +63,6 @@ install(DIRECTORY launch config
 if(BUILD_TESTING)
   # Disable some broken tests for now
   set(ament_cmake_copyright_FOUND TRUE)
-  set(ament_cmake_cpplint_FOUND TRUE)
-  set(ament_cmake_uncrustify_FOUND TRUE)
 
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()

--- a/include/teleop_twist_joy/teleop_twist_joy.hpp
+++ b/include/teleop_twist_joy/teleop_twist_joy.hpp
@@ -22,8 +22,8 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCL
 ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#ifndef TELEOP_TWIST_JOY_TELEOP_TWIST_JOY_H
-#define TELEOP_TWIST_JOY_TELEOP_TWIST_JOY_H
+#ifndef TELEOP_TWIST_JOY__TELEOP_TWIST_JOY_HPP_
+#define TELEOP_TWIST_JOY__TELEOP_TWIST_JOY_HPP_
 
 #include <rclcpp/rclcpp.hpp>
 #include "teleop_twist_joy/teleop_twist_joy_export.h"
@@ -37,16 +37,16 @@ namespace teleop_twist_joy
 class TELEOP_TWIST_JOY_EXPORT TeleopTwistJoy : public rclcpp::Node
 {
 public:
-  explicit TeleopTwistJoy(const rclcpp::NodeOptions& options);
+  explicit TeleopTwistJoy(const rclcpp::NodeOptions & options);
 
   virtual ~TeleopTwistJoy();
 
 private:
   struct Impl;
-  Impl* pimpl_;
-  OnSetParametersCallbackHandle::SharedPtr callback_handle;  
+  Impl * pimpl_;
+  OnSetParametersCallbackHandle::SharedPtr callback_handle;
 };
 
 }  // namespace teleop_twist_joy
 
-#endif  // TELEOP_TWIST_JOY_TELEOP_TWIST_JOY_H
+#endif  // TELEOP_TWIST_JOY__TELEOP_TWIST_JOY_HPP_

--- a/src/teleop_node.cpp
+++ b/src/teleop_node.cpp
@@ -29,7 +29,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 
 #include "teleop_twist_joy/teleop_twist_joy.hpp"
 
-int main(int argc, char *argv[])
+int main(int argc, char * argv[])
 {
   rclcpp::init(argc, argv);
 

--- a/src/teleop_twist_joy.cpp
+++ b/src/teleop_twist_joy.cpp
@@ -29,10 +29,11 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 #include <set>
 #include <string>
 
+#include "rcutils/logging_macros.h"
+
 #include <geometry_msgs/msg/twist.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_components/register_node_macro.hpp>
-#include <rcutils/logging_macros.h>
 #include <sensor_msgs/msg/joy.hpp>
 
 #include "teleop_twist_joy/teleop_twist_joy.hpp"
@@ -51,7 +52,7 @@ namespace teleop_twist_joy
 struct TeleopTwistJoy::Impl
 {
   void joyCallback(const sensor_msgs::msg::Joy::SharedPtr joy);
-  void sendCmdVelMsg(const sensor_msgs::msg::Joy::SharedPtr, const std::string& which_map);
+  void sendCmdVelMsg(const sensor_msgs::msg::Joy::SharedPtr, const std::string & which_map);
 
   rclcpp::Subscription<sensor_msgs::msg::Joy>::SharedPtr joy_sub;
   rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr cmd_vel_pub;
@@ -72,12 +73,14 @@ struct TeleopTwistJoy::Impl
 /**
  * Constructs TeleopTwistJoy.
  */
-TeleopTwistJoy::TeleopTwistJoy(const rclcpp::NodeOptions& options) : Node("teleop_twist_joy_node", options)
+TeleopTwistJoy::TeleopTwistJoy(const rclcpp::NodeOptions & options)
+: rclcpp::Node("teleop_twist_joy_node", options)
 {
   pimpl_ = new Impl;
 
   pimpl_->cmd_vel_pub = this->create_publisher<geometry_msgs::msg::Twist>("cmd_vel", 10);
-  pimpl_->joy_sub = this->create_subscription<sensor_msgs::msg::Joy>("joy", rclcpp::QoS(10),
+  pimpl_->joy_sub = this->create_subscription<sensor_msgs::msg::Joy>(
+    "joy", rclcpp::QoS(10),
     std::bind(&TeleopTwistJoy::Impl::joyCallback, this->pimpl_, std::placeholders::_1));
 
   pimpl_->require_enable_button = this->declare_parameter("require_enable_button", true);
@@ -134,127 +137,106 @@ TeleopTwistJoy::TeleopTwistJoy(const rclcpp::NodeOptions& options) : Node("teleo
   this->declare_parameters("scale_angular_turbo", default_scale_angular_turbo_map);
   this->get_parameters("scale_angular_turbo", pimpl_->scale_angular_map["turbo"]);
 
-  ROS_INFO_COND_NAMED(pimpl_->require_enable_button, "TeleopTwistJoy",
-      "Teleop enable button %" PRId64 ".", pimpl_->enable_button);
-  ROS_INFO_COND_NAMED(pimpl_->enable_turbo_button >= 0, "TeleopTwistJoy",
+  ROS_INFO_COND_NAMED(
+    pimpl_->require_enable_button, "TeleopTwistJoy",
+    "Teleop enable button %" PRId64 ".", pimpl_->enable_button);
+  ROS_INFO_COND_NAMED(
+    pimpl_->enable_turbo_button >= 0, "TeleopTwistJoy",
     "Turbo on button %" PRId64 ".", pimpl_->enable_turbo_button);
 
   for (std::map<std::string, int64_t>::iterator it = pimpl_->axis_linear_map.begin();
-       it != pimpl_->axis_linear_map.end(); ++it)
+    it != pimpl_->axis_linear_map.end(); ++it)
   {
-    ROS_INFO_COND_NAMED(it->second != -1L, "TeleopTwistJoy", "Linear axis %s on %" PRId64 " at scale %f.",
+    ROS_INFO_COND_NAMED(
+      it->second != -1L, "TeleopTwistJoy", "Linear axis %s on %" PRId64 " at scale %f.",
       it->first.c_str(), it->second, pimpl_->scale_linear_map["normal"][it->first]);
-    ROS_INFO_COND_NAMED(pimpl_->enable_turbo_button >= 0 && it->second != -1, "TeleopTwistJoy",
-      "Turbo for linear axis %s is scale %f.", it->first.c_str(), pimpl_->scale_linear_map["turbo"][it->first]);
+    ROS_INFO_COND_NAMED(
+      pimpl_->enable_turbo_button >= 0 && it->second != -1, "TeleopTwistJoy",
+      "Turbo for linear axis %s is scale %f.", it->first.c_str(),
+      pimpl_->scale_linear_map["turbo"][it->first]);
   }
 
   for (std::map<std::string, int64_t>::iterator it = pimpl_->axis_angular_map.begin();
-       it != pimpl_->axis_angular_map.end(); ++it)
+    it != pimpl_->axis_angular_map.end(); ++it)
   {
-    ROS_INFO_COND_NAMED(it->second != -1L, "TeleopTwistJoy", "Angular axis %s on %" PRId64 " at scale %f.",
+    ROS_INFO_COND_NAMED(
+      it->second != -1L, "TeleopTwistJoy", "Angular axis %s on %" PRId64 " at scale %f.",
       it->first.c_str(), it->second, pimpl_->scale_angular_map["normal"][it->first]);
-    ROS_INFO_COND_NAMED(pimpl_->enable_turbo_button >= 0 && it->second != -1, "TeleopTwistJoy",
-      "Turbo for angular axis %s is scale %f.", it->first.c_str(), pimpl_->scale_angular_map["turbo"][it->first]);
+    ROS_INFO_COND_NAMED(
+      pimpl_->enable_turbo_button >= 0 && it->second != -1, "TeleopTwistJoy",
+      "Turbo for angular axis %s is scale %f.", it->first.c_str(),
+      pimpl_->scale_angular_map["turbo"][it->first]);
   }
 
   pimpl_->sent_disable_msg = false;
 
   auto param_callback =
-  [this](std::vector<rclcpp::Parameter> parameters)
-  {
-    rcl_interfaces::msg::SetParametersResult result;
-    result.successful = true;
-
-    // Loop to assign changed parameters to the member variables
-    for (const auto & parameter : parameters)
+    [this](std::vector<rclcpp::Parameter> parameters)
     {
-      if (parameter.get_name() == "require_enable_button")
-      {
-        this->pimpl_->require_enable_button = parameter.get_value<rclcpp::PARAMETER_BOOL>();
+      rcl_interfaces::msg::SetParametersResult result;
+      result.successful = true;
+
+      // Loop to assign changed parameters to the member variables
+      for (const auto & parameter : parameters) {
+        if (parameter.get_name() == "require_enable_button") {
+          this->pimpl_->require_enable_button = parameter.get_value<rclcpp::PARAMETER_BOOL>();
+        } else if (parameter.get_name() == "enable_button") {
+          this->pimpl_->enable_button = parameter.get_value<rclcpp::PARAMETER_INTEGER>();
+        } else if (parameter.get_name() == "enable_turbo_button") {
+          this->pimpl_->enable_turbo_button = parameter.get_value<rclcpp::PARAMETER_INTEGER>();
+        } else if (parameter.get_name() == "axis_linear.x") {
+          this->pimpl_->axis_linear_map["x"] = parameter.get_value<rclcpp::PARAMETER_INTEGER>();
+        } else if (parameter.get_name() == "axis_linear.y") {
+          this->pimpl_->axis_linear_map["y"] = parameter.get_value<rclcpp::PARAMETER_INTEGER>();
+        } else if (parameter.get_name() == "axis_linear.z") {
+          this->pimpl_->axis_linear_map["z"] = parameter.get_value<rclcpp::PARAMETER_INTEGER>();
+        } else if (parameter.get_name() == "axis_angular.yaw") {
+          this->pimpl_->axis_angular_map["yaw"] = parameter.get_value<rclcpp::PARAMETER_INTEGER>();
+        } else if (parameter.get_name() == "axis_angular.pitch") {
+          this->pimpl_->axis_angular_map["pitch"] =
+            parameter.get_value<rclcpp::PARAMETER_INTEGER>();
+        } else if (parameter.get_name() == "axis_angular.roll") {
+          this->pimpl_->axis_angular_map["roll"] = parameter.get_value<rclcpp::PARAMETER_INTEGER>();
+        } else if (parameter.get_name() == "scale_linear_turbo.x") {
+          this->pimpl_->scale_linear_map["turbo"]["x"] =
+            parameter.get_value<rclcpp::PARAMETER_DOUBLE>();
+        } else if (parameter.get_name() == "scale_linear_turbo.y") {
+          this->pimpl_->scale_linear_map["turbo"]["y"] =
+            parameter.get_value<rclcpp::PARAMETER_DOUBLE>();
+        } else if (parameter.get_name() == "scale_linear_turbo.z") {
+          this->pimpl_->scale_linear_map["turbo"]["z"] =
+            parameter.get_value<rclcpp::PARAMETER_DOUBLE>();
+        } else if (parameter.get_name() == "scale_linear.x") {
+          this->pimpl_->scale_linear_map["normal"]["x"] =
+            parameter.get_value<rclcpp::PARAMETER_DOUBLE>();
+        } else if (parameter.get_name() == "scale_linear.y") {
+          this->pimpl_->scale_linear_map["normal"]["y"] =
+            parameter.get_value<rclcpp::PARAMETER_DOUBLE>();
+        } else if (parameter.get_name() == "scale_linear.z") {
+          this->pimpl_->scale_linear_map["normal"]["z"] =
+            parameter.get_value<rclcpp::PARAMETER_DOUBLE>();
+        } else if (parameter.get_name() == "scale_angular_turbo.yaw") {
+          this->pimpl_->scale_angular_map["turbo"]["yaw"] =
+            parameter.get_value<rclcpp::PARAMETER_DOUBLE>();
+        } else if (parameter.get_name() == "scale_angular_turbo.pitch") {
+          this->pimpl_->scale_angular_map["turbo"]["pitch"] =
+            parameter.get_value<rclcpp::PARAMETER_DOUBLE>();
+        } else if (parameter.get_name() == "scale_angular_turbo.roll") {
+          this->pimpl_->scale_angular_map["turbo"]["roll"] =
+            parameter.get_value<rclcpp::PARAMETER_DOUBLE>();
+        } else if (parameter.get_name() == "scale_angular.yaw") {
+          this->pimpl_->scale_angular_map["normal"]["yaw"] =
+            parameter.get_value<rclcpp::PARAMETER_DOUBLE>();
+        } else if (parameter.get_name() == "scale_angular.pitch") {
+          this->pimpl_->scale_angular_map["normal"]["pitch"] =
+            parameter.get_value<rclcpp::PARAMETER_DOUBLE>();
+        } else if (parameter.get_name() == "scale_angular.roll") {
+          this->pimpl_->scale_angular_map["normal"]["roll"] =
+            parameter.get_value<rclcpp::PARAMETER_DOUBLE>();
+        }
       }
-      if (parameter.get_name() == "enable_button")
-      {
-        this->pimpl_->enable_button = parameter.get_value<rclcpp::PARAMETER_INTEGER>();
-      }
-      else if (parameter.get_name() == "enable_turbo_button")
-      {
-        this->pimpl_->enable_turbo_button = parameter.get_value<rclcpp::PARAMETER_INTEGER>();
-      }
-      else if (parameter.get_name() == "axis_linear.x")
-      {
-        this->pimpl_->axis_linear_map["x"] = parameter.get_value<rclcpp::PARAMETER_INTEGER>();
-      }
-      else if (parameter.get_name() == "axis_linear.y")
-      {
-        this->pimpl_->axis_linear_map["y"] = parameter.get_value<rclcpp::PARAMETER_INTEGER>();
-      }
-      else if (parameter.get_name() == "axis_linear.z")
-      {
-        this->pimpl_->axis_linear_map["z"] = parameter.get_value<rclcpp::PARAMETER_INTEGER>();
-      }
-      else if (parameter.get_name() == "axis_angular.yaw")
-      {
-        this->pimpl_->axis_angular_map["yaw"] = parameter.get_value<rclcpp::PARAMETER_INTEGER>();
-      }
-      else if (parameter.get_name() == "axis_angular.pitch")
-      {
-        this->pimpl_->axis_angular_map["pitch"] = parameter.get_value<rclcpp::PARAMETER_INTEGER>();
-      }
-      else if (parameter.get_name() == "axis_angular.roll")
-      {
-        this->pimpl_->axis_angular_map["roll"] = parameter.get_value<rclcpp::PARAMETER_INTEGER>();
-      }
-      else if (parameter.get_name() == "scale_linear_turbo.x")
-      {
-        this->pimpl_->scale_linear_map["turbo"]["x"] = parameter.get_value<rclcpp::PARAMETER_DOUBLE>();
-      }
-      else if (parameter.get_name() == "scale_linear_turbo.y")
-      {
-        this->pimpl_->scale_linear_map["turbo"]["y"] = parameter.get_value<rclcpp::PARAMETER_DOUBLE>();
-      }
-      else if (parameter.get_name() == "scale_linear_turbo.z")
-      {
-        this->pimpl_->scale_linear_map["turbo"]["z"] = parameter.get_value<rclcpp::PARAMETER_DOUBLE>();
-      }
-      else if (parameter.get_name() == "scale_linear.x")
-      {
-        this->pimpl_->scale_linear_map["normal"]["x"] = parameter.get_value<rclcpp::PARAMETER_DOUBLE>();
-      }
-      else if (parameter.get_name() == "scale_linear.y")
-      {
-        this->pimpl_->scale_linear_map["normal"]["y"] = parameter.get_value<rclcpp::PARAMETER_DOUBLE>();
-      }
-      else if (parameter.get_name() == "scale_linear.z")
-      {
-        this->pimpl_->scale_linear_map["normal"]["z"] = parameter.get_value<rclcpp::PARAMETER_DOUBLE>();
-      }
-      else if (parameter.get_name() == "scale_angular_turbo.yaw")
-      {
-        this->pimpl_->scale_angular_map["turbo"]["yaw"] = parameter.get_value<rclcpp::PARAMETER_DOUBLE>();
-      }
-      else if (parameter.get_name() == "scale_angular_turbo.pitch")
-      {
-        this->pimpl_->scale_angular_map["turbo"]["pitch"] = parameter.get_value<rclcpp::PARAMETER_DOUBLE>();
-      }
-      else if (parameter.get_name() == "scale_angular_turbo.roll")
-      {
-        this->pimpl_->scale_angular_map["turbo"]["roll"] = parameter.get_value<rclcpp::PARAMETER_DOUBLE>();
-      }
-      else if (parameter.get_name() == "scale_angular.yaw")
-      {
-        this->pimpl_->scale_angular_map["normal"]["yaw"] = parameter.get_value<rclcpp::PARAMETER_DOUBLE>();
-      }
-      else if (parameter.get_name() == "scale_angular.pitch")
-      {
-        this->pimpl_->scale_angular_map["normal"]["pitch"] = parameter.get_value<rclcpp::PARAMETER_DOUBLE>();
-      }
-      else if (parameter.get_name() == "scale_angular.roll")
-      {
-        this->pimpl_->scale_angular_map["normal"]["roll"] = parameter.get_value<rclcpp::PARAMETER_DOUBLE>();
-      }
-    }
-    return result;
-  };
+      return result;
+    };
 
   callback_handle = this->add_on_set_parameters_callback(param_callback);
 }
@@ -264,13 +246,14 @@ TeleopTwistJoy::~TeleopTwistJoy()
   delete pimpl_;
 }
 
-double getVal(const sensor_msgs::msg::Joy::SharedPtr joy_msg, const std::map<std::string, int64_t>& axis_map,
-              const std::map<std::string, double>& scale_map, const std::string& fieldname)
+double getVal(
+  const sensor_msgs::msg::Joy::SharedPtr joy_msg, const std::map<std::string, int64_t> & axis_map,
+  const std::map<std::string, double> & scale_map, const std::string & fieldname)
 {
   if (axis_map.find(fieldname) == axis_map.end() ||
-      axis_map.at(fieldname) == -1L ||
-      scale_map.find(fieldname) == scale_map.end() ||
-      static_cast<int>(joy_msg->axes.size()) <= axis_map.at(fieldname))
+    axis_map.at(fieldname) == -1L ||
+    scale_map.find(fieldname) == scale_map.end() ||
+    static_cast<int>(joy_msg->axes.size()) <= axis_map.at(fieldname))
   {
     return 0.0;
   }
@@ -278,8 +261,9 @@ double getVal(const sensor_msgs::msg::Joy::SharedPtr joy_msg, const std::map<std
   return joy_msg->axes[axis_map.at(fieldname)] * scale_map.at(fieldname);
 }
 
-void TeleopTwistJoy::Impl::sendCmdVelMsg(const sensor_msgs::msg::Joy::SharedPtr joy_msg,
-                                         const std::string& which_map)
+void TeleopTwistJoy::Impl::sendCmdVelMsg(
+  const sensor_msgs::msg::Joy::SharedPtr joy_msg,
+  const std::string & which_map)
 {
   // Initializes with zeros by default.
   auto cmd_vel_msg = std::make_unique<geometry_msgs::msg::Twist>();
@@ -298,23 +282,19 @@ void TeleopTwistJoy::Impl::sendCmdVelMsg(const sensor_msgs::msg::Joy::SharedPtr 
 void TeleopTwistJoy::Impl::joyCallback(const sensor_msgs::msg::Joy::SharedPtr joy_msg)
 {
   if (enable_turbo_button >= 0 &&
-      static_cast<int>(joy_msg->buttons.size()) > enable_turbo_button &&
-      joy_msg->buttons[enable_turbo_button])
+    static_cast<int>(joy_msg->buttons.size()) > enable_turbo_button &&
+    joy_msg->buttons[enable_turbo_button])
   {
     sendCmdVelMsg(joy_msg, "turbo");
-  }
-  else if (!require_enable_button ||
-	   (static_cast<int>(joy_msg->buttons.size()) > enable_button &&
-           joy_msg->buttons[enable_button]))
+  } else if (!require_enable_button ||  // NOLINT
+    (static_cast<int>(joy_msg->buttons.size()) > enable_button &&
+    joy_msg->buttons[enable_button]))
   {
     sendCmdVelMsg(joy_msg, "normal");
-  }
-  else
-  {
+  } else {
     // When enable button is released, immediately send a single no-motion command
     // in order to stop the robot.
-    if (!sent_disable_msg)
-    {
+    if (!sent_disable_msg) {
       // Initializes with zeros by default.
       auto cmd_vel_msg = std::make_unique<geometry_msgs::msg::Twist>();
       cmd_vel_pub->publish(std::move(cmd_vel_msg));

--- a/src/teleop_twist_joy.cpp
+++ b/src/teleop_twist_joy.cpp
@@ -162,51 +162,8 @@ TeleopTwistJoy::TeleopTwistJoy(const rclcpp::NodeOptions& options) : Node("teleo
   auto param_callback =
   [this](std::vector<rclcpp::Parameter> parameters)
   {
-    static std::set<std::string> intparams = {"axis_linear.x", "axis_linear.y", "axis_linear.z",
-                                              "axis_angular.yaw", "axis_angular.pitch", "axis_angular.roll",
-                                              "enable_button", "enable_turbo_button"};
-    static std::set<std::string> doubleparams = {"scale_linear.x", "scale_linear.y", "scale_linear.z",
-                                                 "scale_linear_turbo.x", "scale_linear_turbo.y", "scale_linear_turbo.z",
-                                                 "scale_angular.yaw", "scale_angular.pitch", "scale_angular.roll",
-                                                 "scale_angular_turbo.yaw", "scale_angular_turbo.pitch", "scale_angular_turbo.roll"};
-    static std::set<std::string> boolparams = {"require_enable_button"};
-    auto result = rcl_interfaces::msg::SetParametersResult();
+    rcl_interfaces::msg::SetParametersResult result;
     result.successful = true;
-
-    // Loop to check if changed parameters are of expected data type
-    for(const auto & parameter : parameters)
-    {
-      if (intparams.count(parameter.get_name()) == 1)
-      {
-        if (parameter.get_type() != rclcpp::ParameterType::PARAMETER_INTEGER)
-        {
-          result.reason = "Only integer values can be set for '" + parameter.get_name() + "'.";
-          RCLCPP_WARN(this->get_logger(), result.reason.c_str());
-          result.successful = false;
-          return result;
-        }
-      }
-      else if (doubleparams.count(parameter.get_name()) == 1)
-      {
-        if (parameter.get_type() != rclcpp::ParameterType::PARAMETER_DOUBLE)
-        {
-          result.reason = "Only double values can be set for '" + parameter.get_name() + "'.";
-          RCLCPP_WARN(this->get_logger(), result.reason.c_str());
-          result.successful = false;
-          return result;
-        }
-      }
-      else if (boolparams.count(parameter.get_name()) == 1)
-      {
-        if (parameter.get_type() != rclcpp::ParameterType::PARAMETER_BOOL)
-        {
-          result.reason = "Only boolean values can be set for '" + parameter.get_name() + "'.";
-          RCLCPP_WARN(this->get_logger(), result.reason.c_str());
-          result.successful = false;
-          return result;
-        }
-      }
-    }
 
     // Loop to assign changed parameters to the member variables
     for (const auto & parameter : parameters)


### PR DESCRIPTION
This small series of commits does a few different things:

1.  It removes the now unnecessary type-checking for parameters.  That is done in the ROS 2 core now, so we don't additionally need to do it here.
2. It cleans up the CMakeLists.txt a bit to use modern CMake constructs.
3. It enables uncrustify and cpplint, and deals with the fallout from that.