### PR TITLE
Update ps3.config.yaml

### DIFF
--- a/config/ps3.config.yaml
+++ b/config/ps3.config.yaml
@@ -12,5 +12,5 @@ teleop_twist_joy_node:
     scale_angular:
       yaw: 0.4
 
-    enable_button: 8  # L2 shoulder button
-    enable_turbo_button: 10  # L1 shoulder button
+    enable_button: 6  # L2 shoulder button
+    enable_turbo_button: 4  # L1 shoulder button


### PR DESCRIPTION
Corrected button numbers to reflect default ps3 controller layout. L2 is 6 and L1 is 4. The prior configuration required the use of the select button as the enable button which was extremely difficult to use.