### PR TITLE
add inverse reverse param

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The package comes with the `teleop_node` that republishes `sensor_msgs/msg/Joy` 
 
 - `enable_button (int, default: 0)`
   - Joystick button to enable regular-speed movement.
-  
+
 - `enable_turbo_button (int, default: -1)`
   - Joystick button to enable high-speed movement (disabled when -1).
 
@@ -51,21 +51,21 @@ The package comes with the `teleop_node` that republishes `sensor_msgs/msg/Joy` 
   - `axis_angular.yaw (int, default: 2)`
   - `axis_angular.pitch (int, default: -1)`
   - `axis_angular.roll (int, default: -1)`
-  
+
 - `scale_angular.<axis>`
   - Scale to apply to joystick angular axis.
   - `scale_angular.yaw (double, default: 0.5)`
   - `scale_angular.pitch (double, default: 0.0)`
   - `scale_angular.roll (double, default: 0.0)`
-  
+
 - `scale_angular_turbo.<axis>`
   - Scale to apply to joystick angular axis for high-speed movement.
   - `scale_angular_turbo.yaw (double, default: 1.0)`
   - `scale_angular_turbo.pitch (double, default: 0.0)`
   - `scale_angular_turbo.roll (double, default: 0.0)`
-    
 
-  
+- `inverted_reverse (bool, default: false)`
+  - Whether to invert turning left-rigth while reversing (useful for differential wheeled robots).
 
 
 # Usage

--- a/src/teleop_twist_joy.cpp
+++ b/src/teleop_twist_joy.cpp
@@ -60,7 +60,7 @@ struct TeleopTwistJoy::Impl
   int64_t enable_button;
   int64_t enable_turbo_button;
 
-  bool inverse_reverse;
+  bool inverted_reverse;
 
   std::map<std::string, int64_t> axis_linear_map;
   std::map<std::string, std::map<std::string, double>> scale_linear_map;
@@ -88,7 +88,7 @@ TeleopTwistJoy::TeleopTwistJoy(const rclcpp::NodeOptions& options) : Node("teleo
 
   pimpl_->enable_turbo_button = this->declare_parameter("enable_turbo_button", -1);
 
-  pimpl_->inverse_reverse = this->declare_parameter("inverse_reverse", false);
+  pimpl_->inverted_reverse = this->declare_parameter("inverted_reverse", false);
 
   std::map<std::string, int64_t> default_linear_map{
     {"x", 5L},
@@ -143,7 +143,7 @@ TeleopTwistJoy::TeleopTwistJoy(const rclcpp::NodeOptions& options) : Node("teleo
   ROS_INFO_COND_NAMED(pimpl_->enable_turbo_button >= 0, "TeleopTwistJoy",
     "Turbo on button %" PRId64 ".", pimpl_->enable_turbo_button);
   ROS_INFO_COND_NAMED(1, "TeleopTwistJoy",
-      "Teleop enable inverse reverse %d.", pimpl_->inverse_reverse);
+      "Teleop enable inverted reverse %d.", pimpl_->inverted_reverse);
 
   for (std::map<std::string, int64_t>::iterator it = pimpl_->axis_linear_map.begin();
        it != pimpl_->axis_linear_map.end(); ++it)
@@ -175,7 +175,7 @@ TeleopTwistJoy::TeleopTwistJoy(const rclcpp::NodeOptions& options) : Node("teleo
                                                  "scale_linear_turbo.x", "scale_linear_turbo.y", "scale_linear_turbo.z",
                                                  "scale_angular.yaw", "scale_angular.pitch", "scale_angular.roll",
                                                  "scale_angular_turbo.yaw", "scale_angular_turbo.pitch", "scale_angular_turbo.roll"};
-    static std::set<std::string> boolparams = {"require_enable_button", "inverse_reverse"};
+    static std::set<std::string> boolparams = {"require_enable_button", "inverted_reverse"};
     auto result = rcl_interfaces::msg::SetParametersResult();
     result.successful = true;
 
@@ -221,9 +221,9 @@ TeleopTwistJoy::TeleopTwistJoy(const rclcpp::NodeOptions& options) : Node("teleo
       {
         this->pimpl_->require_enable_button = parameter.get_value<rclcpp::PARAMETER_BOOL>();
       }
-      if (parameter.get_name() == "inverse_reverse")
+      if (parameter.get_name() == "inverted_reverse")
       {
-        this->pimpl_->inverse_reverse = parameter.get_value<rclcpp::PARAMETER_BOOL>();
+        this->pimpl_->inverted_reverse = parameter.get_value<rclcpp::PARAMETER_BOOL>();
       }
       if (parameter.get_name() == "enable_button")
       {
@@ -343,7 +343,7 @@ void TeleopTwistJoy::Impl::sendCmdVelMsg(const sensor_msgs::msg::Joy::SharedPtr 
   cmd_vel_msg->linear.x = lin_x;
   cmd_vel_msg->linear.y = getVal(joy_msg, axis_linear_map, scale_linear_map[which_map], "y");
   cmd_vel_msg->linear.z = getVal(joy_msg, axis_linear_map, scale_linear_map[which_map], "z");
-  cmd_vel_msg->angular.z = (lin_x < 0.0 && inverse_reverse) ? -ang_z : ang_z;
+  cmd_vel_msg->angular.z = (lin_x < 0.0 && inverted_reverse) ? -ang_z : ang_z;
   cmd_vel_msg->angular.y = getVal(joy_msg, axis_angular_map, scale_angular_map[which_map], "pitch");
   cmd_vel_msg->angular.x = getVal(joy_msg, axis_angular_map, scale_angular_map[which_map], "roll");
 

--- a/src/teleop_twist_joy.cpp
+++ b/src/teleop_twist_joy.cpp
@@ -60,6 +60,8 @@ struct TeleopTwistJoy::Impl
   int64_t enable_button;
   int64_t enable_turbo_button;
 
+  bool inverse_reverse;
+
   std::map<std::string, int64_t> axis_linear_map;
   std::map<std::string, std::map<std::string, double>> scale_linear_map;
 
@@ -85,6 +87,8 @@ TeleopTwistJoy::TeleopTwistJoy(const rclcpp::NodeOptions& options) : Node("teleo
   pimpl_->enable_button = this->declare_parameter("enable_button", 5);
 
   pimpl_->enable_turbo_button = this->declare_parameter("enable_turbo_button", -1);
+
+  pimpl_->inverse_reverse = this->declare_parameter("inverse_reverse", false);
 
   std::map<std::string, int64_t> default_linear_map{
     {"x", 5L},
@@ -138,6 +142,8 @@ TeleopTwistJoy::TeleopTwistJoy(const rclcpp::NodeOptions& options) : Node("teleo
       "Teleop enable button %" PRId64 ".", pimpl_->enable_button);
   ROS_INFO_COND_NAMED(pimpl_->enable_turbo_button >= 0, "TeleopTwistJoy",
     "Turbo on button %" PRId64 ".", pimpl_->enable_turbo_button);
+  ROS_INFO_COND_NAMED(1, "TeleopTwistJoy",
+      "Teleop enable inverse reverse %d.", pimpl_->inverse_reverse);
 
   for (std::map<std::string, int64_t>::iterator it = pimpl_->axis_linear_map.begin();
        it != pimpl_->axis_linear_map.end(); ++it)
@@ -169,7 +175,7 @@ TeleopTwistJoy::TeleopTwistJoy(const rclcpp::NodeOptions& options) : Node("teleo
                                                  "scale_linear_turbo.x", "scale_linear_turbo.y", "scale_linear_turbo.z",
                                                  "scale_angular.yaw", "scale_angular.pitch", "scale_angular.roll",
                                                  "scale_angular_turbo.yaw", "scale_angular_turbo.pitch", "scale_angular_turbo.roll"};
-    static std::set<std::string> boolparams = {"require_enable_button"};
+    static std::set<std::string> boolparams = {"require_enable_button", "inverse_reverse"};
     auto result = rcl_interfaces::msg::SetParametersResult();
     result.successful = true;
 
@@ -214,6 +220,10 @@ TeleopTwistJoy::TeleopTwistJoy(const rclcpp::NodeOptions& options) : Node("teleo
       if (parameter.get_name() == "require_enable_button")
       {
         this->pimpl_->require_enable_button = parameter.get_value<rclcpp::PARAMETER_BOOL>();
+      }
+      if (parameter.get_name() == "inverse_reverse")
+      {
+        this->pimpl_->inverse_reverse = parameter.get_value<rclcpp::PARAMETER_BOOL>();
       }
       if (parameter.get_name() == "enable_button")
       {
@@ -327,10 +337,13 @@ void TeleopTwistJoy::Impl::sendCmdVelMsg(const sensor_msgs::msg::Joy::SharedPtr 
   // Initializes with zeros by default.
   auto cmd_vel_msg = std::make_unique<geometry_msgs::msg::Twist>();
 
-  cmd_vel_msg->linear.x = getVal(joy_msg, axis_linear_map, scale_linear_map[which_map], "x");
+  double lin_x = getVal(joy_msg, axis_linear_map, scale_linear_map[which_map], "x");
+  double ang_z = getVal(joy_msg, axis_angular_map, scale_angular_map[which_map], "yaw");
+
+  cmd_vel_msg->linear.x = lin_x;
   cmd_vel_msg->linear.y = getVal(joy_msg, axis_linear_map, scale_linear_map[which_map], "y");
   cmd_vel_msg->linear.z = getVal(joy_msg, axis_linear_map, scale_linear_map[which_map], "z");
-  cmd_vel_msg->angular.z = getVal(joy_msg, axis_angular_map, scale_angular_map[which_map], "yaw");
+  cmd_vel_msg->angular.z = (lin_x < 0.0 && inverse_reverse) ? -ang_z : ang_z;
   cmd_vel_msg->angular.y = getVal(joy_msg, axis_angular_map, scale_angular_map[which_map], "pitch");
   cmd_vel_msg->angular.x = getVal(joy_msg, axis_angular_map, scale_angular_map[which_map], "roll");
 


### PR DESCRIPTION
Hi!

My story is: our team wanted to use xbox one joystick for controlling our robot with differential wheels in development. But in reverse the turning is inversed. I mean that for example if i want to go forward left then I have to push to joystick to forward and left, but if i want to go reverse left than i have to push the joystick to reverse rigth, so it is not intuitive.

I would like to propose a solution, already implemented and tested.
I have added a new param called "inverse_reverse" which make the joystick work more intuitively, so reverse left means reverse left on joystick as well pushing "M" on teleop twist keyboard.