### PR TITLE
Cleanup CMakeLists.txt.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,13 @@ find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(sensor_msgs REQUIRED)
 
-add_library(${PROJECT_NAME} SHARED src/${PROJECT_NAME})
+add_library(${PROJECT_NAME} SHARED src/teleop_twist_joy.cpp)
+target_link_libraries(${PROJECT_NAME}
+  ${geometry_msgs_TARGETS}
+  rclcpp::rclcpp
+  rclcpp_components::component
+  ${sensor_msgs_TARGETS}
+)
 
 include(GenerateExportHeader)
 generate_export_header(${PROJECT_NAME} EXPORT_FILE_NAME ${PROJECT_NAME}/${PROJECT_NAME}_export.h)
@@ -26,13 +32,6 @@ target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
 set_target_properties(${PROJECT_NAME} PROPERTIES EXPORT_HEADER_DIR "${CMAKE_CURRENT_BINARY_DIR}")
-
-ament_target_dependencies(${PROJECT_NAME}
-  "geometry_msgs"
-  "rclcpp"
-  "rclcpp_components"
-  "sensor_msgs"
-)
 
 rclcpp_components_register_nodes(${PROJECT_NAME}
   "teleop_twist_joy::TeleopTwistJoy")


### PR DESCRIPTION
Use target_link_libraries instead of ament_target_dependencies.

This is already on the `rolling` branch, make sure to backport it to the `humble` branch.