### PR TITLE
Update PS5 Controller Configuration for Teleop Twist Joy Node

### DIFF
--- a/config/ps5.config.yaml
+++ b/config/ps5.config.yaml
@@ -1,0 +1,16 @@
+teleop_twist_joy_node:
+  ros__parameters:
+    axis_linear:
+      x: 1
+    scale_linear:
+      x: 0.7
+    scale_linear_turbo:
+      x: 1.5
+
+    axis_angular:
+      yaw: 0
+    scale_angular:
+      yaw: 0.4
+
+    enable_button: 7  # L2 shoulder button
+    enable_turbo_button: 5  # L1 shoulder button


### PR DESCRIPTION
# Update PS5 Controller Configuration for Teleop Twist Joy Node
## Description:
This Merge Request updates the [config/ps5.config.yaml] file to adjust the configuration for the teleop_twist_joy_node to use the [ps5](https://www.playstation.com/es-es/accessories/dualsense-wireless-controller/) joystick. The changes include:

- Setting the linear axis (x) to 1 and scaling it to 0.7 for normal mode and 1.5 for turbo mode.
- Configuring the angular axis (yaw) to 0 and scaling it to 0.4.
- Assigning the L2 shoulder button (7) as the enable button.
- Assigning the L1 shoulder button (5) as the turbo enable button.
- These changes aim to implement the control experience for the PS5 controller.

## Testing:

- Verify that the linear and angular scaling behaves as expected.
- Confirm that the enable and turbo buttons function correctly.
- Tested controlling a real robot with the ps5 joystick. 