### PR TITLE
Add missing dynamic parameter update for `frame`

### DIFF
--- a/src/teleop_twist_joy.cpp
+++ b/src/teleop_twist_joy.cpp
@@ -259,6 +259,8 @@ TeleopTwistJoy::TeleopTwistJoy(const rclcpp::NodeOptions & options)
         } else if (parameter.get_name() == "scale_angular.roll") {
           this->pimpl_->scale_angular_map["normal"]["roll"] =
             parameter.get_value<rclcpp::PARAMETER_DOUBLE>();
+        } else if (parameter.get_name() == "frame") {
+          this->pimpl_->frame_id = parameter.get_value<rclcpp::PARAMETER_STRING>();
         }
       }
       return result;


### PR DESCRIPTION
## Description
added missing dynamic parameter update for parameter `frame` 

Fixes issue #61

### Is this user-facing behavior change?

No, it behaves the same way by default. The `frame_id` within the header of the TwistStamped message will now change when the user changes the parameter `frame` dynamically .

### Did you use Generative AI?

No

### Additional Information
N/A
