### PR TITLE
add cmd_vel_reliability parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The message type can be changed to `geometry_msgs/msg/TwistStamped` by the `publ
 ## Published Topics
 - `cmd_vel (geometry_msgs/msg/Twist or geometry_msgs/msg/TwistStamped)`
   - Command velocity messages arising from Joystick commands.
+  - QoS reliability can be set by parameter cmd_vel_reliable
 
 ## Parameters
 - `require_enable_button (bool, default: true)`
@@ -103,3 +104,5 @@ __Note:__ this launch file also launches the `joy` node so do not run it separat
   - Path to config files
 - `publish_stamped_twist (bool, default: false)`
   - Whether to publish `geometry_msgs/msg/TwistStamped` for command velocity messages.
+- `cmd_vel_reliable (bool, default: true)`
+  - defines the reliability of topic /cmd_vel  

--- a/launch/teleop-launch.py
+++ b/launch/teleop-launch.py
@@ -10,6 +10,7 @@ def generate_launch_description():
     joy_config = launch.substitutions.LaunchConfiguration('joy_config')
     joy_dev = launch.substitutions.LaunchConfiguration('joy_dev')
     publish_stamped_twist = launch.substitutions.LaunchConfiguration('publish_stamped_twist')
+    cmd_vel_reliable = launch.substitutions.LaunchConfiguration('cmd_vel_reliable')
     config_filepath = launch.substitutions.LaunchConfiguration('config_filepath')
 
     return launch.LaunchDescription([
@@ -17,6 +18,7 @@ def generate_launch_description():
         launch.actions.DeclareLaunchArgument('joy_config', default_value='ps3'),
         launch.actions.DeclareLaunchArgument('joy_dev', default_value='0'),
         launch.actions.DeclareLaunchArgument('publish_stamped_twist', default_value='false'),
+        launch.actions.DeclareLaunchArgument('cmd_vel_reliable', default_value='true'),
         launch.actions.DeclareLaunchArgument('config_filepath', default_value=[
             launch.substitutions.TextSubstitution(text=os.path.join(
                 get_package_share_directory('teleop_twist_joy'), 'config', '')),
@@ -32,7 +34,7 @@ def generate_launch_description():
         launch_ros.actions.Node(
             package='teleop_twist_joy', executable='teleop_node',
             name='teleop_twist_joy_node',
-            parameters=[config_filepath, {'publish_stamped_twist': publish_stamped_twist}],
+            parameters=[config_filepath, {'publish_stamped_twist': publish_stamped_twist, 'cmd_vel_reliable': cmd_vel_reliable}],
             remappings={('/cmd_vel', launch.substitutions.LaunchConfiguration('joy_vel'))},
             ),
     ])

--- a/src/teleop_twist_joy.cpp
+++ b/src/teleop_twist_joy.cpp
@@ -90,14 +90,21 @@ TeleopTwistJoy::TeleopTwistJoy(const rclcpp::NodeOptions & options)
 
   pimpl_->clock = this->get_clock();
 
+  rclcpp::QoS qos(10);
+  if(this->declare_parameter("cmd_vel_reliable", true) ) {
+      qos.reliable();
+  } else {
+      qos.best_effort();
+  }
+
   pimpl_->publish_stamped_twist = this->declare_parameter("publish_stamped_twist", false);
   pimpl_->frame_id = this->declare_parameter("frame", "teleop_twist_joy");
 
   if (pimpl_->publish_stamped_twist) {
     pimpl_->cmd_vel_stamped_pub = this->create_publisher<geometry_msgs::msg::TwistStamped>(
-      "cmd_vel", 10);
+      "cmd_vel", qos);
   } else {
-    pimpl_->cmd_vel_pub = this->create_publisher<geometry_msgs::msg::Twist>("cmd_vel", 10);
+    pimpl_->cmd_vel_pub = this->create_publisher<geometry_msgs::msg::Twist>("cmd_vel", qos);
   }
   pimpl_->joy_sub = this->create_subscription<sensor_msgs::msg::Joy>(
     "joy", rclcpp::QoS(10),


### PR DESCRIPTION
## Description

Add cmd_vel_reliability parameter to change QoS relability of topic /cmd_vel.

### Is this user-facing behavior change?

No, it behaves the same way by default.

### Did you use Generative AI?

No

### Additional Information

QoS of published /cmd_vel topic was incompatible with QoS of subscribed topic of DiffDriveController in ros2_control. 
